### PR TITLE
Updated broken links to Ubuntu READMEs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ we pin the tool to specific version(s).
 * **Regular Weekly Rhythm** can be followed by watching [Releases](https://github.com/actions/virtual-environments/releases). Pre-release is created when deployment is started. As soon as deployment is finished, it is converted to release.
 You can also track upcoming changes using the [awaiting-deployment](https://github.com/actions/virtual-environments/labels/awaiting-deployment) label.
 
-[ubuntu-20.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-[ubuntu-18.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
+[ubuntu-20.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+[ubuntu-18.04]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-Readme.md
 [windows-2022]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
 [windows-2019]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
 [windows-2016]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md


### PR DESCRIPTION
# Description
Ubuntu image READMEs were renamed in https://github.com/actions/virtual-environments/commit/986530d6bb268502c6c29cf7d8c3b1b0b3095bbe (#4974), but these links to them were not updated resulting in broken links.

#### Related issue:
#4974

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
